### PR TITLE
fix: convert relative paths to absolute

### DIFF
--- a/src/pages/customers/create.html
+++ b/src/pages/customers/create.html
@@ -14,10 +14,10 @@
         <a href="#">
           <li class="nav-item nav-item--active"><i class="material-icons">person</i> Customers</li>
         </a>
-        <a href="../items/">
+        <a href="/pages/items/">
           <li class="nav-item"><i class="material-icons">star</i>Items</li>
         </a>
-        <a href="../invoice">
+        <a href="/pages/invoice">
           <li class="nav-item"><i class="material-icons">description</i>Invoices</li>
         </a>
       </ul>

--- a/src/pages/customers/index.html
+++ b/src/pages/customers/index.html
@@ -14,10 +14,10 @@
         <a href="#">
           <li class="nav-item nav-item--active"><i class="material-icons">person</i> Customers</li>
         </a>
-        <a href="../items/">
+        <a href="/pages/items">
           <li class="nav-item"><i class="material-icons">star</i>Items</li>
         </a>
-        <a href="../invoice">
+        <a href="/pages/invoice">
           <li class="nav-item"><i class="material-icons">description</i>Invoices</li>
         </a>
       </ul>
@@ -26,7 +26,7 @@
     <main class="content">
       <header class="content__header">
         <h1>Customers</h1>
-        <a class="btn" href="create.html">
+        <a class="btn" href="/pages/customers/create.html">
           <i class="material-icons btn__icon btn__icon--left">add</i>Add Customers
         </a>
       </header>

--- a/src/pages/items/create.html
+++ b/src/pages/items/create.html
@@ -11,13 +11,13 @@
   <body class="dashboard">
     <nav class="nav-bar">
       <ul>
-        <a href="../customers/">
+        <a href="/pages/customers/">
           <li class="nav-item"><i class="material-icons">person</i> Customers</li>
         </a>
-        <a href="/">
+        <a href="#">
           <li class="nav-item nav-item--active"><i class="material-icons">star</i>Items</li>
         </a>
-        <a href="../invoice">
+        <a href="/pages/invoice">
           <li class="nav-item"><i class="material-icons">description</i>Invoices</li>
         </a>
       </ul>

--- a/src/pages/items/index.html
+++ b/src/pages/items/index.html
@@ -11,13 +11,13 @@
   <body class="dashboard">
     <nav class="nav-bar">
       <ul>
-        <a href="../customers">
+        <a href="/pages/customers">
           <li class="nav-item"><i class="material-icons">person</i> Customers</li>
         </a>
         <a href="#">
           <li class="nav-item nav-item--active"><i class="material-icons">star</i>Items</li>
         </a>
-        <a href="../invoice">
+        <a href="/pages/invoice">
           <li class="nav-item"><i class="material-icons">description</i>Invoices</li>
         </a>
       </ul>
@@ -26,7 +26,7 @@
     <main class="content">
       <header class="content__header">
         <h1>Items</h1>
-        <a class="btn" href="create.html">
+        <a class="btn" href="/pages/items/create.html">
           <i class="material-icons btn__icon btn__icon--left">add</i>Add Item
         </a>
       </header>


### PR DESCRIPTION
# Description

Some anchor tags do not point to the right urls, when served using a server. This issue is caused due to the relative paths. If merged, this PR will resolve that issue by converting all relative paths to absolute paths

fixes #21 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas